### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <div align="center">
 
-# Optimist Documentation
+# GEC Customer Documentation
 
-This repository contains the documentation for the Optimist platform.
+This repository contains the customer documentation for GEC.
 
 </div>
 


### PR DESCRIPTION
Fix the title of the documentation to say GEC instead of Optimist, as this is our new - unified - documentation