### PR TITLE
add docs for new k8s version v1.21.2

### DIFF
--- a/docs/_imke/about/changelog-v2.17/index.de.md
+++ b/docs/_imke/about/changelog-v2.17/index.de.md
@@ -14,6 +14,7 @@ Im Rahmen des aktuellen Release werden die folgenden Kubernetes-Versionen unters
 * 1.19.10
 * 1.19.11
 * 1.20.7
+* 1.21.2
 
 ## End of Life Ankündigungen
 
@@ -29,7 +30,7 @@ Bitte updaten Sie alle bestehenden Cluster mit Kubernetes Version 1.18 auf minde
 
 ### Upgrade-Hinweise für Kubernetes 1.20
 
-Wenn Sie ein Upgrade auf Kubernetes 1.20 planen, lesen Sie bitte den Abschnitt [Upgrade Notes](https://v1-2ß.docs.kubernetes.io/docs/setup/release/notes/#urgent-upgrade-notes) des offiziellen Kubernetes v1.20 Changelogs und machen Sie sich mit den bevorstehenden Änderungen vertraut.
+Wenn Sie ein Upgrade auf Kubernetes 1.20 planen, lesen Sie bitte den Abschnitt [Upgrade Notes](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#urgent-upgrade-notes) des offiziellen Kubernetes v1.20 Changelogs und machen Sie sich mit den bevorstehenden Änderungen vertraut.
 
 Eine Übersicht über die Änderungen finden Sie im Abschnitt [Changes by Kind](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#changes-by-kind) des Changelogs.
 
@@ -37,3 +38,14 @@ Eine Übersicht über die Änderungen finden Sie im Abschnitt [Changes by Kind](
 * [Deprecations](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#deprecation)
 * [API-Änderungen](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#api-change)
 * [Features](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#feature)
+
+### Upgrade-Hinweise für Kubernetes 1.21
+
+Wenn Sie ein Upgrade auf Kubernetes 1.21 planen, lesen Sie bitte den Abschnitt [What's New](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#whats-new-major-themes) des offiziellen Kubernetes v1.21 Changelogs und machen Sie sich mit den bevorstehenden Änderungen vertraut.
+
+Eine Übersicht über die Änderungen finden Sie im Abschnitt [Changes by Kind](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#changes-by-kind-2) des Changelogs.
+
+* [Wichtige Hinweise zum Upgrade](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#urgent-upgrade-notes)
+* [Deprecations](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#deprecation)
+* [API-Änderungen](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#api-change-1)
+* [Features](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#feature-2)

--- a/docs/_imke/about/changelog-v2.17/index.en.md
+++ b/docs/_imke/about/changelog-v2.17/index.en.md
@@ -14,6 +14,7 @@ With the current release, we support the following Kubernetes versions:
 * 1.19.10
 * 1.19.11
 * 1.20.7
+* 1.21.2
 
 ## End of Life announcements
 
@@ -24,6 +25,7 @@ Please make sure to upgrade all existing clusters running 1.18 at least to 1.19 
 ## New features
 
 * Added support for Kubernetes 1.20
+* Added support for Kubernetes 1.21
 
 ## Bugfixes
 
@@ -41,3 +43,14 @@ For an overview of the changes, please refer to the [Changes by Kind](https://v1
 * [Deprecations](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#deprecation)
 * [API changes](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#api-change)
 * [Features](https://v1-20.docs.kubernetes.io/docs/setup/release/notes/#feature)
+
+### Upgrade notes for Kubernetes 1.21
+
+If you are planning to upgrade to Kubernetes 1.21, please have a look at the [What's new](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#whats-new-major-themes) section of the official Kubernetes v1.21 release notes and make sure you familiarise yourself with the upcoming changes.
+
+For an overview of the changes, please refer to the [Changes by Kind](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#changes-by-kind-2) section of the Changelog.
+
+* [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#urgent-upgrade-notes)
+* [Deprecations](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#deprecation)
+* [API changes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#api-change-1)
+* [Features](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#feature-2)

--- a/docs/_imke/about/kubernetesversions/index.de.md
+++ b/docs/_imke/about/kubernetesversions/index.de.md
@@ -11,6 +11,7 @@ Folgende Kubernetes Versionen unterstützen wir aktuell in iMKE.
 
 | Version | iMKE Deprecation| iMKE End-of-Life |
 |---------|-----------------|------------------|
+| v1.21   |                 |                  |
 | v1.20   |                 |                  |
 | v1.19   |                 | November 2021    |
 | v1.18   | 14.06.2021      | 15.9.2021        |

--- a/docs/_imke/about/kubernetesversions/index.en.md
+++ b/docs/_imke/about/kubernetesversions/index.en.md
@@ -12,6 +12,7 @@ Current supported Kubernetes versions in iMKE.
 
 | Version | iMKE Deprecation| iMKE End-of-Life |
 |---------|-----------------|------------------|
+| v1.21   |                 |                  |
 | v1.20   |                 |                  |
 | v1.19   |                 | November 2021    |
 | v1.18   | 14th Jun 2021   | 15th Sep 2021    |


### PR DESCRIPTION
This PR add documentation to the newly added k8s version v1.21.2.

Please take note that the documentation in the `changelog-v2.17/index.*` files changes in style as there are no nicely rendered doc-pages for current kubernetes version (like there are for the archived ones which you can access via https://v1-20.docs.kubernetes.io/docs/...). Please take a closer look if this is ok from an aesthetic point of view! 