### PR TITLE
Linux Paketname aktualisiert

### DIFF
--- a/docs/_optimist/guided_tour/step04/index.de.md
+++ b/docs/_optimist/guided_tour/step04/index.de.md
@@ -183,7 +183,7 @@ Collecting python-openstackclient
 Zunächst wird auch hier `pip` benötigt, dafür wird `apt-get` genutzt:
 
 ```bash
-$ sudo apt-get install python-pip
+$ sudo apt-get install python3-pip
 Reading package lists... Done
 Building dependency tree
 Reading state information... Done
@@ -193,7 +193,7 @@ Sobald die Installation von `pip` abgeschlossen ist, wird nun die
 Virtuelle Umgebung angelegt:
 
 ```bash
-$ sudo apt install python-virtualenv
+$ sudo apt-get install python3-virtualenv
 Reading package lists... Done
 Building dependency tree
 Reading state information... Done


### PR DESCRIPTION
python-pip und python-virtualenv gibt es in Ubuntu 20.04 nicht mehr, hier muss python3-pip und python3-virtualenv installiert werden