### PR TITLE
Linux Paketname aktualisiert

### DIFF
--- a/docs/_optimist/guided_tour/step04/index.en.md
+++ b/docs/_optimist/guided_tour/step04/index.en.md
@@ -147,7 +147,7 @@ Once pip is installed, we can install the OpenStack client:
 To start things off, we'll install pip.
 
 ```
-$ sudo apt-get install python-pip
+$ sudo apt-get install python3-pip
 Reading package lists... Done
 Building dependency tree
 Reading state information... Done
@@ -157,7 +157,7 @@ Next, we'll install virtualenv, which we'll need to set up our virtual
 environment.
 
 ```
-$ sudo apt install python-virtualenv
+$ sudo apt-get install python3-virtualenv
 Reading package lists... Done
 Building dependency tree
 Reading state information... Done


### PR DESCRIPTION
python-pip und python-virtualenv gibt es in Ubuntu 20.04 nicht mehr, hier muss python3-pip und python3-virtualenv installiert werden