### PR TITLE
feat(doc): add documentation for append-only restic+rclone backups

### DIFF
--- a/docs/_optimist/storage/s3_documentation/backupwithrestic/index.de.md
+++ b/docs/_optimist/storage/s3_documentation/backupwithrestic/index.de.md
@@ -1,0 +1,189 @@
+---
+title: Sichere Datensicherung mit Restic und Rclone
+lang: de
+permalink: /optimist/storage/s3_documentation/backupwithrestic/
+nav_order: 3170
+parent: S3 Kompatiblen Objekt Storage
+grand_parent: Storage
+---
+
+Restic ist eine sehr einfache und leistungsstarke file-basierte Backup-Lösung, die schnell an Popularität gewinnt. Es kann in Kombination mit S3 verwendet werden, was es zu einem großartigen Werkzeug für Optimist macht.
+
+## Problemstellung
+
+Beim Durchführen von Sicherungen auf Dateiebene eines Nodes in S3 benötigt die Sicherungssoftware Schreibberechtigungen für den S3-Bucket.
+
+Verschafft sich ein Angreifer jedoch Zugriff auf die Maschine, kann er auch die Backups im Bucket zerstören, da die S3-Anmeldeinformationen auf dem kompromittierten System vorhanden sind.
+
+Die Lösung kann so einfach sein, wie die Zugriffsebene der Backup-Software auf den Bucket einzuschränken. Leider ist das bei S3 nicht trivial.
+
+## Hintergrund
+
+S3-Zugriffskontrolllisten (ACLs) ermöglichen Ihnen die Verwaltung des Zugriffs auf Buckets und Objekte, sind jedoch sehr eingeschränkt. Sie unterscheiden im Wesentlichen READ- und WRITE-Berechtigungen:
+
+* LESEN – Ermöglicht dem Benutzer, die Objekte im Bucket aufzulisten
+* WRITE - Ermöglicht dem Benutzer, jedes Objekt im Bucket zu erstellen, zu überschreiben und zu löschen
+
+Die Einschränkungen von ACLs wurden durch die Zugriffsrichtlinienberechtigungen (ACP) behoben. Wir könnten dem Bucket eine No-Delete-Richtlinie anhängen, z.B.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "nodelete1",
+            "Effect": "Deny",
+            "Action": [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:DeleteObject",
+                "s3:DeleteObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*"
+            ]
+        }
+    ]
+}
+```
+
+Leider wurde das S3-Protokoll selbst nicht mit dem Konzept von WORM-Backups (Write Once Read Many) im Hinterkopf entwickelt. Zugriffsrichtlinienberechtigungen unterscheiden nicht zwischen dem Ändern eines vorhandenen Objekts (was ein effektives Löschen ermöglichen würde) und dem Erstellen eines neuen Objekts.
+
+Das Anhängen der obigen Richtlinie an einen Bucket verhindert nicht das Überschreiben der darin enthaltenen Objekte.
+
+```bash
+$ s3cmd put testfile s3://appendonly-bucket/testfile
+upload: 'testfile' -> 's3://appendonly-bucket/testfile' [1 of 1]
+ 1054 of 1054 100% in 0s 5.46 KB/s done     # die Richtlinie erlaubt Schreiben
+$ s3cmd rm s3://appendonly-bucket/testfile
+ERROR: S3 error: 403 (AccessDenied)         # die Richtlinie verweigert das Löschen
+$
+$ s3cmd put testfile s3://appendonly-bucket/testfile
+upload: 'testfile' -> 's3://appendonly-bucket/testfile' [1 of 1]
+ 1054 of 1054 100% in 0s 5.50 KB/s done     # :(
+```
+
+## Vorgeschlagene Lösung
+
+Da ein Angreifer auf einem kompromittierten System immer Zugriff auf die S3-Anmeldeinformationen und jeden auf dem System laufenden Dienst hat – einschließlich Restic selbst, Proxys usw. – benötigen wir eine zweite, abgesicherte VM, die Löschvorgänge einschränken kann. Restic lässt sich perfekt in rclone integrieren, daher verwenden wir es in diesem Beispiel.
+
+### Our environment
+
+* `appsrv`: das zu sichernde System, mit Zugriff auf die Sicherungen
+* `rclonesrv`: das System, auf dem der rclone-Proxy ausgeführt wird (und nichts anderes, um die Angriffsfläche zu minimieren)
+
+### Den rclone-Proxy einrichten
+
+1. rclone auf dem `rclonesrv` installieren:
+
+    ```bash
+    sudo apt install rclone
+    ```
+
+1. User für rclone anlegen
+
+    ```bash
+    sudo useradd -m rcloneproxy
+    sudo su - rcloneproxy
+    ```
+
+1. Die Backend-Konfiguration für rclone backend erstellen
+
+    ```bash
+    mkdir -p .config/rclone
+    cat << EOF > .config/rclone/rclone.conf
+    [s3-resticrepo]
+    type = s3
+    provider = Other
+    env_auth = false
+    access_key_id = 111122223333444455556666
+    secret_access_key = aaaabbbbccccddddeeeeffffgggghhhh
+    region = eu-central-1
+    endpoint = s3.es1.fra.optimist.innovo.cloud
+    acl = private
+    bucket_acl = private
+    upload_concurrency = 8
+    EOF
+    ```
+
+1. Den Zugriff auf das Repository testen:
+
+    ```bash
+    rclone lsd s3-resticrepo:databucket
+            0 2021-11-21 20:02:10        -1 data
+            0 2021-11-21 20:02:10        -1 index
+            0 2021-11-21 20:02:10        -1 keys
+            0 2021-11-21 20:02:10        -1 snapshots
+    ```
+
+### Den Appserver konfigurieren
+
+1. Ein SSH-Schlüsselpaar auf `appsrv` mit dem Benutzer generieren, mit dem Sie das Backup durchführen:
+
+    ```bash
+    ssh-keygen -o -a 256 -t ed25519 -C "$(hostname)-$(date +'%d-%m-%Y')"
+    ```
+
+1. Die Umgebungsvariablen für restic setzen:
+
+    ```bash
+    export RESTIC_PASSWORD="MyV3ryS3cUr3r3571cP4ssW0rd"
+    export RESTIC_REPOSITORY=rclone:s3-resticrepo:databucket
+    ```
+
+### Den SSH-Schlüssel auf restic-only Befehle beschränken
+
+Der letzte Schritt ist nun die SSH-Datei `authorized_keys` auf dem `rclonesrv` zu bearbeiten, um den neu generierten SSH-Schlüssel auf einen einzigen Befehl zu beschränken. Auf diese Weise kann ein Angreifer das SSH-Schlüsselpaar nicht verwenden, um beliebige Befehle auf dem rclone-Proxy auszuführen und die Backups zu kompromittieren.
+
+```bash
+vi ~/.ssh/authorized_keys
+# Fügen Sie inen Eintrag mit dem öffentlichen Schlüssel des restic-Benutzers hinzu, der in dem obigen Schritt generiert wurde:
+command="rclone serve restic --stdio --append-only s3-resticrepo:databucket" ssh-ed25519 AAAAC3fdsC1lZddsDNTE5ADsaDgfTwNtWmwiocdT9q4hxcss6tGDfgGTdiNN0z7zN appsrv-18-11-2021
+```
+
+## restic mit dem rclone Proxy verwenden
+
+Wenn die Umgebungsvariablen gesetzt sind, sollte restic jetzt von dem `appsrv` aus funktionieren.
+
+Beispiel: Sicherung von `/srv/myapp`:
+
+```bash
+restic -o rclone.program="ssh rcloneproxy@rclonesrv.mydomain.com" backup /srv/myapp
+```
+
+Snapshots auflisten:
+
+```bash
+restic -o rclone.program="ssh rcloneproxy@rclonesrv.mydomain.com" snapshots
+```
+
+Snapshots löschen:
+
+```bash
+restic -o rclone.program="ssh rcloneproxy@rclonesrv.mydomain.com" forget 2738e969
+repository b71c391e opened successfully, password is correct
+Remove(<snapshot/2738e9693b>) returned error, retrying after 446.577749ms: blob not removed, server response: 403 Forbidden (403)
+```
+
+Ah, das geht nicht. Das war ja unser Ziel!
+
+## Zusammenfassung
+
+Auf dieser Art und Weise,
+
+* der rclone-Proxy auf dem `rclonerv` läuft nicht einmal als Dienst. Es wird nur bei Bedarf für die Dauer der Restic-Operation gestartet. Die Kommunikation erfolgt über HTTP2 über stdin/stdout in einem verschlüsselten SSH-Tunnel.
+* Da rclone mit `--append-only` läuft, ist es nicht möglich, Snapshots im S3-Bucket zu löschen (oder zu überschreiben).
+* Alle Daten (außer Zugangsdaten) werden lokal verschlüsselt/entschlüsselt und dann über `rclonesrv` an/von S3 gesendet/empfangen.
+* Alle Zugangsdaten werden **nur** auf `rclonesrv` gespeichert, um mit S3 zu kommunizieren.
+
+Da der Befehl in der SSH-Konfiguration für den SSH-Schlüssel des Benutzers fest eingetragen ist, gibt es keine Möglichkeit, den Schlüssel zu verwenden, um Zugriff auf den rclone-Proxy zu erhalten.
+
+## Noch ein paar Gedanken
+
+Die Vorteile der Lösung sind wahrscheinlich schon klar. Im Weiteren,
+
+* die Verwaltung von Snapshots (sowohl manuell als auch mit einer Aufbewahrungsrichtlinie) ist nur noch auf dem rclone-Proxy möglich.
+* Eine einzelne rclone-Proxy-VM (oder sogar ein Docker-Container auf einer isolierten VM) kann mehrere Backup-Clients bedienen.
+* Es ist sehr empfohlen, für jeden Server, der Daten sichert, einen eigenen Schlüssel zu verwenden.
+* Wenn Sie mehr als ein Repository aus einem Node verwenden möchten, benötigen Sie dafür neue SSH-Schlüssel. Sie können dann mit `-i ~/.ssh/id_ed25519_another_repo` in den `rclone.program`-Argumenten genau wie bei SSH angeben, welcher Schlüssel verwendet werden soll.

--- a/docs/_optimist/storage/s3_documentation/backupwithrestic/index.de.md
+++ b/docs/_optimist/storage/s3_documentation/backupwithrestic/index.de.md
@@ -19,9 +19,9 @@ Die Lösung kann so einfach sein, wie die Zugriffsebene der Backup-Software auf 
 
 ## Hintergrund
 
-S3-Zugriffskontrolllisten (ACLs) ermöglichen Ihnen die Verwaltung des Zugriffs auf Buckets und Objekte, sind jedoch sehr eingeschränkt. Sie unterscheiden im Wesentlichen READ- und WRITE-Berechtigungen:
+[S3-Zugriffskontrolllisten (ACLs)](/optimist/storage/s3_documentation/security) ermöglichen Ihnen die Verwaltung des Zugriffs auf Buckets und Objekte, sind jedoch sehr eingeschränkt. Sie unterscheiden im Wesentlichen READ- und WRITE-Berechtigungen:
 
-* LESEN – Ermöglicht dem Benutzer, die Objekte im Bucket aufzulisten
+* READ– Ermöglicht dem Benutzer, die Objekte im Bucket aufzulisten
 * WRITE - Ermöglicht dem Benutzer, jedes Objekt im Bucket zu erstellen, zu überschreiben und zu löschen
 
 Die Einschränkungen von ACLs wurden durch die Zugriffsrichtlinienberechtigungen (ACP) behoben. Wir könnten dem Bucket eine No-Delete-Richtlinie anhängen, z.B.

--- a/docs/_optimist/storage/s3_documentation/backupwithrestic/index.de.md
+++ b/docs/_optimist/storage/s3_documentation/backupwithrestic/index.de.md
@@ -21,7 +21,7 @@ Die Lösung kann so einfach sein, wie die Zugriffsebene der Backup-Software auf 
 
 [S3-Zugriffskontrolllisten (ACLs)](/optimist/storage/s3_documentation/security) ermöglichen Ihnen die Verwaltung des Zugriffs auf Buckets und Objekte, sind jedoch sehr eingeschränkt. Sie unterscheiden im Wesentlichen READ- und WRITE-Berechtigungen:
 
-* READ– Ermöglicht dem Benutzer, die Objekte im Bucket aufzulisten
+* READ – Ermöglicht dem Benutzer, die Objekte im Bucket aufzulisten
 * WRITE - Ermöglicht dem Benutzer, jedes Objekt im Bucket zu erstellen, zu überschreiben und zu löschen
 
 Die Einschränkungen von ACLs wurden durch die Zugriffsrichtlinienberechtigungen (ACP) behoben. Wir könnten dem Bucket eine No-Delete-Richtlinie anhängen, z.B.

--- a/docs/_optimist/storage/s3_documentation/backupwithrestic/index.en.md
+++ b/docs/_optimist/storage/s3_documentation/backupwithrestic/index.en.md
@@ -1,0 +1,189 @@
+---
+title: Secure Backups with Restic and Rclone
+lang: en
+permalink: /optimist/storage/s3_documentation/backupwithrestic/
+nav_order: 3170
+parent: S3 Kompatiblen Objekt Storage
+grand_parent: Storage
+---
+
+Restic is a very simple and powerful file-level backup solution, which is rapidly gaining popularity. It can be used in combination with S3 which makes it a great tool to use on Optimist.
+
+## Problem statement
+
+When performing file-level backups of a node into S3, the backup software needs write permissions for the S3 bucket.
+
+But if an attacker gains access to the machine, he can also destroy the backups in the bucket, since the S3 credentials are present on the compromised system.
+
+The solution can be as simple as limiting the level of access of the backup software to the bucket. Unfortunately, this isn't trivial with S3.
+
+## Background
+
+S3 access control lists (ACLs) enable you to manage access to buckets and objects, but are very limited. They essentially differentiate READ and WRITE permissions:
+
+* READ - Allows grantee to list the objects in the bucket
+* WRITE - Allows grantee to create, overwrite, and delete any object in the bucket
+
+The limitations of ACLs were addressed by the access policy permissions (ACP). We could attach a no-delete policy to the bucket, e.g.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "nodelete1",
+            "Effect": "Deny",
+            "Action": [
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucketWebsite",
+                "s3:DeleteObject",
+                "s3:DeleteObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*"
+            ]
+        }
+    ]
+}
+```
+
+Unfortunately, the S3 protocol itself wasn't designed with the concept of WORM (write once read many) backups in mind. Access policy permissions do not differentiate between changing an existing object (which would allow effectively deleting it) and creating a new object.
+
+Attaching the above policy on a bucket does not prevent from overwriting the objects in it.
+
+```bash
+$ s3cmd put testfile s3://appendonly-bucket/testfile
+upload: 'testfile' -> 's3://appendonly-bucket/testfile' [1 of 1]
+ 1054 of 1054 100% in 0s 5.46 KB/s done     # policy allows write
+$ s3cmd rm s3://appendonly-bucket/testfile
+ERROR: S3 error: 403 (AccessDenied)         # policy denies deletion
+$
+$ s3cmd put testfile s3://appendonly-bucket/testfile
+upload: 'testfile' -> 's3://appendonly-bucket/testfile' [1 of 1]
+ 1054 of 1054 100% in 0s 5.50 KB/s done     # :(
+```
+
+## Proposed solution
+
+Since an attacker on a compromised system will always have access to the S3 credentials and every service running on the system - including restic itself, proxies, etc. - we need a second, locked-down VM which can restrict delete operations. Restic can be integrated perfectly with rclone, so we'll use it in this example.
+
+### Our environment
+
+* `appsrv`: the system which has access to the files we would like to backup
+* `rclonesrv`: the system running the rclone proxy (and nothing else, to minimise the attack surface)
+
+### Set up the rclone proxy
+
+1. Install rclone on the `rclonesrv`
+
+    ```bash
+    sudo apt install rclone
+    ```
+
+1. Create user for rclone
+
+    ```bash
+    sudo useradd -m rcloneproxy
+    sudo su - rcloneproxy
+    ```
+
+1. Create rclone backend configuration
+
+    ```bash
+    mkdir -p .config/rclone
+    cat << EOF > .config/rclone/rclone.conf
+    [s3-resticrepo]
+    type = s3
+    provider = Other
+    env_auth = false
+    access_key_id = 111122223333444455556666
+    secret_access_key = aaaabbbbccccddddeeeeffffgggghhhh
+    region = eu-central-1
+    endpoint = s3.es1.fra.optimist.innovo.cloud
+    acl = private
+    bucket_acl = private
+    upload_concurrency = 8
+    EOF
+    ```
+
+1. Verify that the access to the repository is working with:
+
+    ```bash
+    rclone lsd s3-resticrepo:databucket
+            0 2021-11-21 20:02:10        -1 data
+            0 2021-11-21 20:02:10        -1 index
+            0 2021-11-21 20:02:10        -1 keys
+            0 2021-11-21 20:02:10        -1 snapshots
+    ```
+
+### Configure the appserver
+
+1. Generate an SSH-Keypair on `appsrv` with the user you're performing the backup with:
+
+    ```bash
+    ssh-keygen -o -a 256 -t ed25519 -C "$(hostname)-$(date +'%d-%m-%Y')"
+    ```
+
+1. Set the environment variables for restic:
+
+    ```bash
+    export RESTIC_PASSWORD="MyV3ryS3cUr3r3571cP4ssW0rd"
+    export RESTIC_REPOSITORY=rclone:s3-resticrepo:databucket
+    ```
+
+### Restrict the SSH key to restic-only commands
+
+The last step is to go back to the `rclonesrv` and edit the SSH `authorized_keys` file to restrict the newly generated SSH key to a single command. This way, an attacker is not able to use the ssh keypair to run arbitrary commands on the rclone proxy and compromise the backups.
+
+```bash
+vi ~/.ssh/authorized_keys
+# add an entry with the restic user's public key generated in a previous step:
+command="rclone serve restic --stdio --append-only s3-resticrepo:databucket" ssh-ed25519 AAAAC3fdsC1lZddsDNTE5ADsaDgfTwNtWmwiocdT9q4hxcss6tGDfgGTdiNN0z7zN appsrv-18-11-2021
+```
+
+## Using restic with the rclone proxy
+
+With the environment variables set, restic should work now from `appsrv`.
+
+Example backing up `/srv/myapp`:
+
+```bash
+restic -o rclone.program="ssh rcloneproxy@rclonesrv.mydomain.com" backup /srv/myapp
+```
+
+Listing snapshots:
+
+```bash
+restic -o rclone.program="ssh rcloneproxy@rclonesrv.mydomain.com" snapshots
+```
+
+Deleting snapshots:
+
+```bash
+restic -o rclone.program="ssh rcloneproxy@rclonesrv.mydomain.com" forget 2738e969
+repository b71c391e opened successfully, password is correct
+Remove(<snapshot/2738e9693b>) returned error, retrying after 446.577749ms: blob not removed, server response: 403 Forbidden (403)
+```
+
+Oh, right, that doesn't work. That was our goal!
+
+## Summary
+
+This way,
+
+* the rclone proxy doesn't even run on the `rclonesrv` as a service. It will just be spawned on demand, for the duration of the restic operation. Communication happens over HTTP2 over stdin/stdout, in an encrypted SSH tunnel.
+* Since rclone is running with `--append-only`, it is not possible to delete (or overwrite) snapshots in the S3 bucket.
+* All data (except credentials) is encrypted/decrypted locally, then sent/received via `rclonesrv` to/from S3.
+* All the credentials are **only** stored on `rclonesrv` to communicate with S3.
+
+Since the command is hard-coded into the SSH configuration for the user's SSH key, there is no way to use the the keys to get access to the rclone proxy.
+
+## Some more thoughts
+
+The advantages of this construct are probably clear already by now. Furthermore,
+
+* managing snapshots (both manually and with a retention policy) is only possible on the rclone proxy.
+* A single rclone proxy VM (or even a docker container on an isolated VM) can serve multiple backup clients.
+* It is highly recommended to use one key for every server which backs up data.
+* If you'd like to use more than one repository out of a node, you'll need new SSH keys for them. You can then specify which key to use with `-i ~/.ssh/id_ed25519_another_repo` in the `rclone.program` arguments just like you would with SSH.

--- a/docs/_optimist/storage/s3_documentation/backupwithrestic/index.en.md
+++ b/docs/_optimist/storage/s3_documentation/backupwithrestic/index.en.md
@@ -7,7 +7,7 @@ parent: S3 Kompatiblen Objekt Storage
 grand_parent: Storage
 ---
 
-Restic is a very simple and powerful file-level backup solution, which is rapidly gaining popularity. It can be used in combination with S3 which makes it a great tool to use on Optimist.
+Restic is a very simple and powerful file-level backup solution, which is rapidly gaining popularity. It can be used in combination with S3 which makes it a great tool to use with Optimist.
 
 ## Problem statement
 
@@ -19,12 +19,12 @@ The solution can be as simple as limiting the level of access of the backup soft
 
 ## Background
 
-S3 access control lists (ACLs) enable you to manage access to buckets and objects, but are very limited. They essentially differentiate READ and WRITE permissions:
+[S3 access control lists (ACLs)](/optimist/storage/s3_documentation/security) enable you to manage access to buckets and objects, but they have limitations. They essentially differentiate READ and WRITE permissions:
 
 * READ - Allows grantee to list the objects in the bucket
 * WRITE - Allows grantee to create, overwrite, and delete any object in the bucket
 
-The limitations of ACLs were addressed by the access policy permissions (ACP). We could attach a no-delete policy to the bucket, e.g.
+The limitations of ACLs were addressed by the access policy permissions (ACP). We can attach a no-delete policy to the bucket, e.g.
 
 ```json
 {
@@ -48,9 +48,9 @@ The limitations of ACLs were addressed by the access policy permissions (ACP). W
 }
 ```
 
-Unfortunately, the S3 protocol itself wasn't designed with the concept of WORM (write once read many) backups in mind. Access policy permissions do not differentiate between changing an existing object (which would allow effectively deleting it) and creating a new object.
+Unfortunately, the S3 protocol itself wasn't designed with the concept of WORM (write once read many) backups in mind. Access policy permissions do not differentiate between changing an existing object (which would effectively allow deleting it) and creating a new object.
 
-Attaching the above policy on a bucket does not prevent from overwriting the objects in it.
+Attaching the above policy on a bucket does not prevent the objects in it from being overwritten.
 
 ```bash
 $ s3cmd put testfile s3://appendonly-bucket/testfile
@@ -172,7 +172,7 @@ Oh, right, that doesn't work. That was our goal!
 
 This way,
 
-* the rclone proxy doesn't even run on the `rclonesrv` as a service. It will just be spawned on demand, for the duration of the restic operation. Communication happens over HTTP2 over stdin/stdout, in an encrypted SSH tunnel.
+* The rclone proxy doesn't even run on the `rclonesrv` as a service. It will just be spawned on demand, for the duration of the restic operation. Communication happens over HTTP2 over stdin/stdout, in an encrypted SSH tunnel.
 * Since rclone is running with `--append-only`, it is not possible to delete (or overwrite) snapshots in the S3 bucket.
 * All data (except credentials) is encrypted/decrypted locally, then sent/received via `rclonesrv` to/from S3.
 * All the credentials are **only** stored on `rclonesrv` to communicate with S3.
@@ -183,7 +183,7 @@ Since the command is hard-coded into the SSH configuration for the user's SSH ke
 
 The advantages of this construct are probably clear already by now. Furthermore,
 
-* managing snapshots (both manually and with a retention policy) is only possible on the rclone proxy.
+* Managing snapshots (both manually and with a retention policy) is only possible on the rclone proxy.
 * A single rclone proxy VM (or even a docker container on an isolated VM) can serve multiple backup clients.
 * It is highly recommended to use one key for every server which backs up data.
 * If you'd like to use more than one repository out of a node, you'll need new SSH keys for them. You can then specify which key to use with `-i ~/.ssh/id_ed25519_another_repo` in the `rclone.program` arguments just like you would with SSH.


### PR DESCRIPTION
add documentation on how to configure restic in combination with rclone to allow for WORM backups.

needs thorough review.