### PR TITLE
fix(doc): fix parent page for the ro-restic doc

### DIFF
--- a/docs/_optimist/storage/s3_documentation/backupwithrestic/index.en.md
+++ b/docs/_optimist/storage/s3_documentation/backupwithrestic/index.en.md
@@ -3,7 +3,7 @@ title: Secure Backups with Restic and Rclone
 lang: en
 permalink: /optimist/storage/s3_documentation/backupwithrestic/
 nav_order: 3170
-parent: S3 Kompatiblen Objekt Storage
+parent: S3 Compatible Object Storage
 grand_parent: Storage
 ---
 


### PR DESCRIPTION
The parent page was pointing to the German parent page in both the English and German version.

Fix the English version's parent.