### PR TITLE
Remove info about bug with ED25519 SSH keys

### DIFF
--- a/docs/_optimist/faq/index.de.md
+++ b/docs/_optimist/faq/index.de.md
@@ -33,16 +33,6 @@ nur mit dem Openstack Client möglich. Zum Beispiel:
 openstack security group rule create --remote-ip 10.0.0.0/24 --protocol vrrp --ethertype IPv4 --ingress  default
 ```
 
-## Kann ich ED25519 SSH Keys verwenden?
-
-Aktuell ist die Nutzung von ED25519 SSH-Keys nicht möglich.
-
-Der Grund dafür liegt an der fehlenden Implementierung in OpenSSL, welche für die Bereitstellung von TLS und HTTP Services in OpenStack
-genutzt wird. Der Fortschritt der Entwicklung ist einsehbar unter:
-
-- [OpenSSL Issue #487](https://github.com/openssl/openssl/issues/487)
-- [OpenStack Bugtracker #1555521](https://bugs.launchpad.net/nova/+bug/1555521)
-
 ## Warum werden mir Floating IPs berechnet, die ich gar nicht benutze?
 
 Der Grund dafür ist mit hoher Wahrscheinlichkeit, dass Floating IPs erstellt wurden, aber nach der Benutzung nicht korrekt gelöscht wurden.

--- a/docs/_optimist/faq/index.en.md
+++ b/docs/_optimist/faq/index.en.md
@@ -33,15 +33,6 @@ OpenStack client! An example of adding VRRP to a security group would be:
 openstack security group rule create --remote-ip 10.0.0.0/24 --protocol vrrp --ethertype IPv4 --ingress  default
 ```
 
-## Is it possible to use ED25519 SSH keys?
-
-For now, it's not possible to use ED25519 SSH keys.
-
-There is a bug in OpenSSL that's needed for the TLS layer in OpenStack. You can track the progress of this bug in these two tickets:
-
-- [OpenSSL Issue #487](https://github.com/openssl/openssl/issues/487)
-- [OpenStack Bugtracker #1555521](https://bugs.launchpad.net/nova/+bug/1555521)
-
 ## Why am I charged for Floating IPs I am not using?
 
 We have to charge for reserved Floating IPs, and most often the case is that you did not remove the Floating IP after deleting the VM that


### PR DESCRIPTION
- With the upgrade, ed25519 ssh keys are working once again.
- Removed bug info from the FAQ