### PR TITLE
Additional info on Flavor resize added

### DIFF
--- a/docs/_optimist/specs/flavor_specification/index.de.md
+++ b/docs/_optimist/specs/flavor_specification/index.de.md
@@ -15,7 +15,7 @@ verfügbaren Flavors aufgelistet sind.
 
 ## Migration zwischen Flavor-Typen
 
-Um die Flavors bestehender Instanzen zu ändern, kann die OpenStack-Option [„Resize Instance“](/optimist/faq/#wie-kann-ich-den-flavor-einer-instanz-ändern-instance-resize) entweder über das Dashboard oder die CLI verwendet werden. Dies führt zu einem Neustart der Instanz, aber der Inhalt der Instanz bleibt erhalten. Bitte beachten Sie, dass die Größe von Flavors nur von `small` auf `large` geändert werden kann (und nicht umgekehrt).
+Um die Flavors bestehender Instanzen zu ändern, kann die OpenStack-Option [„Resize Instance“](/optimist/faq/#wie-kann-ich-den-flavor-einer-instanz-ändern-instance-resize) entweder über das Dashboard oder die CLI verwendet werden. Dies führt zu einem Neustart der Instanz, aber der Inhalt der Instanz bleibt erhalten. Bitte beachten Sie, dass ein Wechsel der Flavors von den großen Root-Disk-Typen zu einem Flavor mit einer kleineren Root-Disk nicht möglich ist.
 
 {: .warning-title }
 >Warnung

--- a/docs/_optimist/specs/flavor_specification/index.de.md
+++ b/docs/_optimist/specs/flavor_specification/index.de.md
@@ -15,7 +15,7 @@ verfügbaren Flavors aufgelistet sind.
 
 ## Migration zwischen Flavor-Typen
 
-Um die Flavors bestehender Instanzen zu ändern, kann die OpenStack-Option „Resize Instance“ entweder über das Dashboard oder die CLI verwendet werden. Dies führt zu einem Neustart der Instanz, aber der Inhalt der Instanz bleibt erhalten.
+Um die Flavors bestehender Instanzen zu ändern, kann die OpenStack-Option [„Resize Instance“](/optimist/faq/#wie-kann-ich-den-flavor-einer-instanz-ändern-instance-resize) entweder über das Dashboard oder die CLI verwendet werden. Dies führt zu einem Neustart der Instanz, aber der Inhalt der Instanz bleibt erhalten. Bitte beachten Sie, dass die Größe von Flavors nur von `small` auf `large` geändert werden kann (und nicht umgekehrt).
 
 {: .warning-title }
 >Warnung

--- a/docs/_optimist/specs/flavor_specification/index.en.md
+++ b/docs/_optimist/specs/flavor_specification/index.en.md
@@ -14,7 +14,7 @@ various standard hardware profiles (flavors). These have different limits, which
 
 ## Migrating between Flavor Types
 
-To change the flavors of existing instances, the OpenStack "Resize Instance" Option can be used either via the Dashboard or the CLI. This will result in a reboot of the Instance but the content of the instance will be preserved.
+To change the flavors of existing instances, the OpenStack ["Resize Instance"](/optimist/faq/#how-can-i-change-the-flavor-of-a-virtual-machine-instance-resize) Option can be used either via the Dashboard or the CLI. This will result in a reboot of the Instance but the content of the instance will be preserved. Please note that Flavors can only be resized from `small` up to `large` (and not the reverse).
 
 {: .warning }
 This does not apply to l1 (localstorage) flavors

--- a/docs/_optimist/specs/flavor_specification/index.en.md
+++ b/docs/_optimist/specs/flavor_specification/index.en.md
@@ -14,7 +14,7 @@ various standard hardware profiles (flavors). These have different limits, which
 
 ## Migrating between Flavor Types
 
-To change the flavors of existing instances, the OpenStack ["Resize Instance"](/optimist/faq/#how-can-i-change-the-flavor-of-a-virtual-machine-instance-resize) Option can be used either via the Dashboard or the CLI. This will result in a reboot of the Instance but the content of the instance will be preserved. Please note that Flavors can only be resized from `small` up to `large` (and not the reverse).
+To change the flavors of existing instances, the OpenStack ["Resize Instance"](/optimist/faq/#how-can-i-change-the-flavor-of-a-virtual-machine-instance-resize) Option can be used either via the Dashboard or the CLI. This will result in a reboot of the Instance but the content of the instance will be preserved. Please note that changing Flavors from Large Root Disk Types to a Flavor with a smaller Root Disk is not possible.
 
 {: .warning }
 This does not apply to l1 (localstorage) flavors


### PR DESCRIPTION
- In our FAQ we have info on how to resize flavors https://docs.gec.io/optimist/faq/#how-can-i-change-the-flavor-of-a-virtual-machine-instance-resize
- This was linked to section https://docs.gec.io/optimist/specs/flavor_specification/#migrating-between-flavor-types 
- Outlined that only small -> large flavor changes are possible.